### PR TITLE
Fault source attributes

### DIFF
--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -102,8 +102,8 @@ def create_faultsource(fault, name):
     low_d_min low_d_max low_d_pref low_d_com
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
-    aseis_slip aseis_com created compiler 
-    mov_min mov_max mov_pref contrib
+    aseis_slip aseis_com created compiler all_com
+    mov_min mov_max mov_pref contrib 
     """.strip().split()
 
     

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -104,7 +104,6 @@ def create_faultsource(fault, name):
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
     aseis_slip aseis_com created compiler
     mov_min mov_max mov_pref contrib
-    episodi_is episodi_ac down_thro
     """.strip().split()
 
     

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -102,9 +102,8 @@ def create_faultsource(fault, name):
     low_d_min low_d_max low_d_pref low_d_com
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
-    aseis_slip aseis_com created compiler all_com
-    mov_min mov_max mov_pref contrib strike
-    episodi_is episodi_ac down_thro
+    aseis_slip aseis_com created compiler 
+    mov_min mov_max mov_pref contrib
     """.strip().split()
 
     

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -103,9 +103,10 @@ def create_faultsource(fault, name):
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
     aseis_slip aseis_com
-    mov_min mov_max mov_pref
+    mov_min mov_max mov_pref contrib
     """.strip().split()
 
+    
     a = dict((attrib_name, getattr(fault, attrib_name))
              for attrib_name in verbatim_attributes)
     a.update(dict(

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -103,7 +103,7 @@ def create_faultsource(fault, name):
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
     aseis_slip aseis_com created compiler all_com
-    mov_min mov_max mov_pref contrib 
+    mov_min mov_max mov_pref contrib strike
     """.strip().split()
 
     

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -102,8 +102,9 @@ def create_faultsource(fault, name):
     low_d_min low_d_max low_d_pref low_d_com
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
-    aseis_slip aseis_com created compiler all_com
-    mov_min mov_max mov_pref contrib strike
+    aseis_slip aseis_com created compiler
+    mov_min mov_max mov_pref contrib
+    episodi_is episodi_ac down_thro
     """.strip().split()
 
     

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -102,8 +102,9 @@ def create_faultsource(fault, name):
     low_d_min low_d_max low_d_pref low_d_com
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
-    aseis_slip aseis_com
-    mov_min mov_max mov_pref contrib
+    aseis_slip aseis_com created compiler all_com
+    mov_min mov_max mov_pref contrib strike
+    episodi_is episodi_ac down_thro
     """.strip().split()
 
     


### PR DESCRIPTION
Currently the faulted earth tool requires that every attribute of the fault record is not null before a fault source can be generated. This constraint should be limited only to the fields that are required.

This issue has been resolved by adding the appropriate attribute names to the Django function that is used to create a fault source.

https://bugs.launchpad.net/openquake/+bug/953845
