### PR TITLE
Fault source fields

### DIFF
--- a/geonode/observations/models.py
+++ b/geonode/observations/models.py
@@ -24,7 +24,7 @@ from django.contrib.gis.db import models
 
 class FaultSource(models.Model):
     fault = models.ForeignKey('Fault')
-    source_nm = models.CharField(max_length=30)
+    fault_name = models.CharField(max_length=30)
 
     length_min = models.FloatField(null=True, blank=True)
     length_max = models.FloatField(null=True, blank=True)

--- a/geonode/observations/utils.py
+++ b/geonode/observations/utils.py
@@ -103,7 +103,7 @@ def create_faultsource(fault, name):
     dip_min dip_max dip_pref dip_com dip_dir
     slip_typ slip_com slip_r_min slip_r_max slip_r_pre slip_r_com
     aseis_slip aseis_com created compiler
-    mov_min mov_max mov_pref contrib
+    mov_min mov_max mov_pref contrib fault_name
     """.strip().split()
 
     


### PR DESCRIPTION
this pull will change change the fault source name to fault_name so that the named filed in the fault table can be copied over to the fault source record

https://bugs.launchpad.net/openquake/+bug/954017
