### PR TITLE
bugfix 963088

### DIFF
--- a/geonode/observations/models.py
+++ b/geonode/observations/models.py
@@ -146,6 +146,8 @@ class Fault(models.Model):
     created = models.DateField(null=True, blank=True)
     simple_geom = models.MultiLineStringField(srid=4326, null=True, blank=True)
 
+    def __unicode__(self):
+        return "Fault %s %s" % (self.pk, self.fault_name)
 
 class FaultSection(models.Model):
     fault = models.ManyToManyField('Fault')


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/963088

Also addresses another bug. When reusing a jvm pipe we need to ensure that it is proper reattached to the request thread
